### PR TITLE
added module.exports

### DIFF
--- a/build/circular-json.node.js
+++ b/build/circular-json.node.js
@@ -178,3 +178,5 @@ function parseRecursion(text, reviver) {
 }
 this.stringify = stringifyRecursion;
 this.parse = parseRecursion;
+
+module.exports = this;


### PR DESCRIPTION
When I tried to use this on react-native, the class' functions were missing

`
var CircularJSON = require('circular-json');
CircularJSON.stringify({foo: 'bar'});
`

Let me know if there is a more elegant solution to this